### PR TITLE
Support "glibtoolize" and fix Issue #2

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -6,7 +6,13 @@ AUTOMAKE=`which automake 2>/dev/null`
 AUTOHEADER=`which autoheader 2>/dev/null`
 AUTOCONF=`which autoconf 2>/dev/null`
 
-libtoolize --copy --install --force
+# On some platforms, "libtoolize" gets installed as "glibtoolize"
+LIBTOOLIZE=`which libtoolize 2> /dev/null`
+if test "$?" -eq 1; then
+    LIBTOOLIZE=`which glibtoolize 2> /dev/null`
+fi
+
+${LIBTOOLIZE} --copy --install --force
 $ACLOCAL
 $AUTOHEADER
 $AUTOMAKE --foreign --add-missing --copy


### PR DESCRIPTION
On Mac OS X systems (and maybe elsewhere) the "libtool" and "libtoolize"
programs are installed in the path as "glibtool" and "glibtoolize",
respectively. This makes the hardcoded "libtoolize" incompatible.